### PR TITLE
doc: update README with Sylius exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,16 @@ twig_trace:
         - meta
         - stylesheets
         - javascripts
+        # For Sylius, add the following line
+        - body_class
     
     # Template paths to exclude from tracing
     excluded_paths:
         - 'email/'           # Exclude email templates
         - 'pdf/'             # Exclude PDF templates
         - '@EasyAdmin'       # Exclude EasyAdmin templates
+        # For Sylius, add the following line
+        - '@SyliusUi/macro/rtl.html.twig'
 ```
 
 ### Configuration Reference


### PR DESCRIPTION
The `rtl.html.twig` file is used in the `<html>` tag, which breaks things.

The `body_class` block is used in the `class="…"` attribute of the `<body>` tag in admin.

Those two new lines seem to fix issues in either frontend and backend for Sylius.

I suggest adding them in the README, it's enough I guess.

Maybe adding a new section in the README could help, otherwise, it's prefect!

And it works now like a charm!

